### PR TITLE
account for case when all tags have the same weight

### DIFF
--- a/js/tagcloud.js
+++ b/js/tagcloud.js
@@ -8,7 +8,7 @@
         tagWeights = jQuery.makeArray(tagWeights).sort(compareWeights);
         lowest = tagWeights[0];
         highest = tagWeights.pop();
-        range = highest - lowest;
+        range = Math.max(highest - lowest, 1);
         // Sizes
         if (opts.size) {
             fontIncr = (opts.size.end - opts.size.start) / range;


### PR DESCRIPTION
Hi!
If all tags have equivalent weight, tag styles are not applied. I added Math.max() wrapper to account for that case.
And thanks for the plugin! =)